### PR TITLE
Improve .NET 8 idioms

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Bounded on both ends                         | `Bounded(C, BoundType, C, BoundTy
 Unbounded on top (`(a..+∞)` or `[a..+∞)`)    | `DownTo(C, BoundType)`
 Unbounded on bottom (`(-∞..b)` or `(-∞..b]`) | `UpTo(C, BoundType)`
 
-Here, `BoundType` is an enum containing the values `CLOSED` and `OPEN`.
+Here, `BoundType` is an enum containing the values `Closed` and `Open`.
 
 ```cs
 Range.DownTo(4, boundType); // allows you to decide whether or not you want to include 4
-Range.Bounded(1, BoundType.CLOSED, 4, BoundType.OPEN); // another way of writing Range.ClosedOpen(1, 4)
+Range.Bounded(1, BoundType.Closed, 4, BoundType.Open); // another way of writing Range.ClosedOpen(1, 4)
 ```
 
 ## Operations
@@ -95,7 +95,7 @@ To look at the endpoints of a range, `Range` exposes the following methods:
 *   `HasLowerBound()` and `HasUpperBound()`, which check if the range has
     the specified endpoints, or goes on "through infinity."
 *   `LowerBoundType()` and `UpperBoundType()` return the `BoundType` for the
-    corresponding endpoint, which can be either `CLOSED` or `OPEN`. If this
+    corresponding endpoint, which can be either `Closed` or `Open`. If this
     range does not have the specified endpoint, the method throws an
     `InvalidOperationException`.
 *   `LowerEndpoint()` and `UpperEndpoint()` return the endpoints on the
@@ -112,8 +112,8 @@ Range.Open(4, 4).IsEmpty(); // Range.Open throws ArgumentException
 
 Range.Closed(3, 10).LowerEndpoint(); // returns 3
 Range.Open(3, 10).LowerEndpoint(); // returns 3
-Range.Closed(3, 10).LowerBoundType(); // returns CLOSED
-Range.Open(3, 10).UpperBoundType(); // returns OPEN
+Range.Closed(3, 10).LowerBoundType(); // returns Closed
+Range.Open(3, 10).UpperBoundType(); // returns Open
 ```
 
 ### Interval Operations

--- a/src/DotRange.Tests/RangeTest.cs
+++ b/src/DotRange.Tests/RangeTest.cs
@@ -21,10 +21,10 @@ public class RangeTest
         range.Contains(8).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(4);
-        range.LowerBoundType().Should().Be(BoundType.OPEN);
+        range.LowerBoundType().Should().Be(BoundType.Open);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(8);
-        range.UpperBoundType().Should().Be(BoundType.OPEN);
+        range.UpperBoundType().Should().Be(BoundType.Open);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("(4..8)");
     }
@@ -49,10 +49,10 @@ public class RangeTest
         range.Contains(8).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(5);
-        range.LowerBoundType().Should().Be(BoundType.CLOSED);
+        range.LowerBoundType().Should().Be(BoundType.Closed);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(7);
-        range.UpperBoundType().Should().Be(BoundType.CLOSED);
+        range.UpperBoundType().Should().Be(BoundType.Closed);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("[5..7]");
     }
@@ -74,10 +74,10 @@ public class RangeTest
         range.Contains(8).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(4);
-        range.LowerBoundType().Should().Be(BoundType.OPEN);
+        range.LowerBoundType().Should().Be(BoundType.Open);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(7);
-        range.UpperBoundType().Should().Be(BoundType.CLOSED);
+        range.UpperBoundType().Should().Be(BoundType.Closed);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("(4..7]");
     }
@@ -92,10 +92,10 @@ public class RangeTest
         range.Contains(8).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(5);
-        range.LowerBoundType().Should().Be(BoundType.CLOSED);
+        range.LowerBoundType().Should().Be(BoundType.Closed);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(8);
-        range.UpperBoundType().Should().Be(BoundType.OPEN);
+        range.UpperBoundType().Should().Be(BoundType.Open);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("[5..8)");
     }
@@ -121,10 +121,10 @@ public class RangeTest
         range.Contains(5).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(4);
-        range.LowerBoundType().Should().Be(BoundType.CLOSED);
+        range.LowerBoundType().Should().Be(BoundType.Closed);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(4);
-        range.UpperBoundType().Should().Be(BoundType.CLOSED);
+        range.UpperBoundType().Should().Be(BoundType.Closed);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("[4..4]");
     }
@@ -138,10 +138,10 @@ public class RangeTest
         range.Contains(5).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(4);
-        range.LowerBoundType().Should().Be(BoundType.CLOSED);
+        range.LowerBoundType().Should().Be(BoundType.Closed);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(4);
-        range.UpperBoundType().Should().Be(BoundType.OPEN);
+        range.UpperBoundType().Should().Be(BoundType.Open);
         range.IsEmpty().Should().BeTrue();
         range.ToString().Should().Be("[4..4)");
     }
@@ -155,10 +155,10 @@ public class RangeTest
         range.Contains(5).Should().BeFalse();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(4);
-        range.LowerBoundType().Should().Be(BoundType.OPEN);
+        range.LowerBoundType().Should().Be(BoundType.Open);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(4);
-        range.UpperBoundType().Should().Be(BoundType.CLOSED);
+        range.UpperBoundType().Should().Be(BoundType.Closed);
         range.IsEmpty().Should().BeTrue();
         range.ToString().Should().Be("(4..4]");
     }
@@ -173,7 +173,7 @@ public class RangeTest
         AssertUnboundedBelow(range);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(5);
-        range.UpperBoundType().Should().Be(BoundType.OPEN);
+        range.UpperBoundType().Should().Be(BoundType.Open);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("(-\u221e..5)");
     }
@@ -187,7 +187,7 @@ public class RangeTest
         range.Contains(int.MaxValue).Should().BeTrue();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(5);
-        range.LowerBoundType().Should().Be(BoundType.OPEN);
+        range.LowerBoundType().Should().Be(BoundType.Open);
         AssertUnboundedAbove(range);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("(5..+\u221e)");
@@ -202,7 +202,7 @@ public class RangeTest
         range.Contains(int.MaxValue).Should().BeTrue();
         range.HasLowerBound().Should().BeTrue();
         range.LowerEndpoint().Should().Be(6);
-        range.LowerBoundType().Should().Be(BoundType.CLOSED);
+        range.LowerBoundType().Should().Be(BoundType.Closed);
         AssertUnboundedAbove(range);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("[6..+\u221e)");
@@ -218,7 +218,7 @@ public class RangeTest
         AssertUnboundedBelow(range);
         range.HasUpperBound().Should().BeTrue();
         range.UpperEndpoint().Should().Be(4);
-        range.UpperBoundType().Should().Be(BoundType.CLOSED);
+        range.UpperBoundType().Should().Be(BoundType.Closed);
         range.IsEmpty().Should().BeFalse();
         range.ToString().Should().Be("(-\u221e..4]");
     }
@@ -463,7 +463,7 @@ public class RangeTest
     public void Equals()
     {
         Range<int> open1 = Range.Open(1, 5);
-        Range<int> open2 = Range.Bounded(1, BoundType.OPEN, 5, BoundType.OPEN);
+        Range<int> open2 = Range.Bounded(1, BoundType.Open, 5, BoundType.Open);
 
         open1.Should().Be(open1);
         open1.Should().Be(open2);
@@ -485,14 +485,14 @@ public class RangeTest
     [Test]
     public void EquivalentFactories()
     {
-        Range.AtLeast(1).Should().Be(Range.DownTo(1, BoundType.CLOSED));
-        Range.GreaterThan(1).Should().Be(Range.DownTo(1, BoundType.OPEN));
-        Range.AtMost(7).Should().Be(Range.UpTo(7, BoundType.CLOSED));
-        Range.LessThan(7).Should().Be(Range.UpTo(7, BoundType.OPEN));
-        Range.Open(1, 7).Should().Be(Range.Bounded(1, BoundType.OPEN, 7, BoundType.OPEN));
-        Range.OpenClosed(1, 7).Should().Be(Range.Bounded(1, BoundType.OPEN, 7, BoundType.CLOSED));
-        Range.Closed(1, 7).Should().Be(Range.Bounded(1, BoundType.CLOSED, 7, BoundType.CLOSED));
-        Range.ClosedOpen(1, 7).Should().Be(Range.Bounded(1, BoundType.CLOSED, 7, BoundType.OPEN));
+        Range.AtLeast(1).Should().Be(Range.DownTo(1, BoundType.Closed));
+        Range.GreaterThan(1).Should().Be(Range.DownTo(1, BoundType.Open));
+        Range.AtMost(7).Should().Be(Range.UpTo(7, BoundType.Closed));
+        Range.LessThan(7).Should().Be(Range.UpTo(7, BoundType.Open));
+        Range.Open(1, 7).Should().Be(Range.Bounded(1, BoundType.Open, 7, BoundType.Open));
+        Range.OpenClosed(1, 7).Should().Be(Range.Bounded(1, BoundType.Open, 7, BoundType.Closed));
+        Range.Closed(1, 7).Should().Be(Range.Bounded(1, BoundType.Closed, 7, BoundType.Closed));
+        Range.ClosedOpen(1, 7).Should().Be(Range.Bounded(1, BoundType.Closed, 7, BoundType.Open));
     }
 
     [Test]
@@ -502,9 +502,9 @@ public class RangeTest
         lexiRange.Contains("lift").Should().BeTrue();
         Range.LessThan(4.0);
 
-        var boundType = BoundType.CLOSED;
+        var boundType = BoundType.Closed;
         Range.DownTo(4, boundType);
-        Range.Bounded(1, BoundType.CLOSED, 4, BoundType.OPEN);
+        Range.Bounded(1, BoundType.Closed, 4, BoundType.Open);
 
         Range.Closed(1, 3).Contains(2).Should().BeTrue();
         Range.Closed(1, 3).Contains(4).Should().BeFalse();
@@ -519,8 +519,8 @@ public class RangeTest
 
         Range.Closed(3, 10).LowerEndpoint().Should().Be(3);
         Range.Open(3, 10).LowerEndpoint().Should().Be(3);
-        Range.Closed(3, 10).LowerBoundType().Should().Be(BoundType.CLOSED);
-        Range.Open(3, 10).UpperBoundType().Should().Be(BoundType.OPEN);
+        Range.Closed(3, 10).LowerBoundType().Should().Be(BoundType.Closed);
+        Range.Open(3, 10).UpperBoundType().Should().Be(BoundType.Open);
 
         Range.Closed(3, 6).Encloses(Range.Closed(4, 5)).Should().BeTrue();
         Range.Open(3, 6).Encloses(Range.Open(3, 6)).Should().BeTrue();

--- a/src/DotRange/BoundType.cs
+++ b/src/DotRange/BoundType.cs
@@ -10,6 +10,6 @@ namespace DotRange;
 [Serializable]
 public enum BoundType
 {
-	OPEN,
-	CLOSED
+    Open,
+    Closed
 }

--- a/src/DotRange/Cut.cs
+++ b/src/DotRange/Cut.cs
@@ -197,11 +197,11 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
         }
         internal override BoundType TypeAsLowerBound()
         {
-            return BoundType.CLOSED;
+            return BoundType.Closed;
         }
         internal override BoundType TypeAsUpperBound()
         {
-            return BoundType.OPEN;
+            return BoundType.Open;
         }
         internal override void DescribeAsLowerBound(StringBuilder sb)
         {
@@ -233,11 +233,11 @@ internal abstract class Cut<C> : IComparable<Cut<C>> where C : IComparable<C>
         }
         internal override BoundType TypeAsLowerBound()
         {
-            return BoundType.OPEN;
+            return BoundType.Open;
         }
         internal override BoundType TypeAsUpperBound()
         {
-            return BoundType.CLOSED;
+            return BoundType.Closed;
         }
         internal override void DescribeAsLowerBound(StringBuilder sb)
         {

--- a/src/DotRange/Range.cs
+++ b/src/DotRange/Range.cs
@@ -58,8 +58,8 @@ public static class Range
     /// </exception>
     public static Range<C> Bounded<C>(C lower, BoundType lowerType, C upper, BoundType upperType) where C : IComparable<C>
     {
-        Cut<C> lowerBound = (lowerType == BoundType.OPEN) ? Cut.AboveValue(lower) : Cut.BelowValue(lower);
-        Cut<C> upperBound = (upperType == BoundType.OPEN) ? Cut.BelowValue(upper) : Cut.AboveValue(upper);
+        Cut<C> lowerBound = (lowerType == BoundType.Open) ? Cut.AboveValue(lower) : Cut.BelowValue(lower);
+        Cut<C> upperBound = (upperType == BoundType.Open) ? Cut.BelowValue(upper) : Cut.AboveValue(upper);
         return new Range<C>(lowerBound, upperBound);
     }
 
@@ -87,12 +87,12 @@ public static class Range
     {
         switch (boundType)
         {
-            case BoundType.OPEN:
+            case BoundType.Open:
                 return LessThan(endpoint);
-            case BoundType.CLOSED:
+            case BoundType.Closed:
                 return AtMost(endpoint);
             default:
-                throw new Exception();
+                throw new ArgumentOutOfRangeException(nameof(boundType), boundType, "Invalid bound type");
         }
     }
 
@@ -120,12 +120,12 @@ public static class Range
     {
         switch (boundType)
         {
-            case BoundType.OPEN:
+            case BoundType.Open:
                 return GreaterThan(endpoint);
-            case BoundType.CLOSED:
+            case BoundType.Closed:
                 return AtLeast(endpoint);
             default:
-                throw new Exception();
+                throw new ArgumentOutOfRangeException(nameof(boundType), boundType, "Invalid bound type");
         }
     }
 
@@ -254,8 +254,8 @@ public sealed class Range<C> where C : IComparable<C>
     }
 
     /// <summary>
-    /// Returns the type of this range's lower bound: <seealso cref="BoundType.CLOSED"/> if the range includes
-    /// its lower endpoint, <seealso cref="BoundType.OPEN"/> if it does not.
+    /// Returns the type of this range's lower bound: <seealso cref="BoundType.Closed"/> if the range includes
+    /// its lower endpoint, <seealso cref="BoundType.Open"/> if it does not.
     /// </summary>
     /// <exception cref="InvalidOperationException"> if this range is unbounded below
     /// (that is, <seealso cref="Range{C}.HasLowerBound"/> returns <c>false</c>)</exception>
@@ -282,8 +282,8 @@ public sealed class Range<C> where C : IComparable<C>
     }
 
     /// <summary>
-    /// Returns the type of this range's upper bound: <seealso cref="BoundType.CLOSED"/> if the range includes
-    /// its upper endpoint, <seealso cref="BoundType.OPEN"/> if it does not.
+    /// Returns the type of this range's upper bound: <seealso cref="BoundType.Closed"/> if the range includes
+    /// its upper endpoint, <seealso cref="BoundType.Open"/> if it does not.
     /// </summary>
     /// <exception cref="InvalidOperationException"> if this range is unbounded above 
     /// (that is, <seealso cref="Range{C}.HasUpperBound"/> returns <c>false</c>)</exception>
@@ -489,7 +489,7 @@ public sealed class Range<C> where C : IComparable<C>
     /// </summary>
     public override int GetHashCode()
     {
-        return _lowerBound.GetHashCode() * 31 + _upperBound.GetHashCode();
+        return HashCode.Combine(_lowerBound, _upperBound);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- rename `BoundType` enum values to PascalCase
- throw `ArgumentOutOfRangeException` for invalid bound types
- use `HashCode.Combine` when hashing `Range`

## Testing
- `dotnet test`